### PR TITLE
add use strict

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@
  * Created by Amir on 02/09/16.
  */
 
+"use strict";
+
 var request = require('request');
 var cheerio = require('cheerio');
 var Q = require('q');


### PR DESCRIPTION
It's because it's compiling to ES6 and the browser is requiring that block-scoped declarations be used in strict mode.